### PR TITLE
Fixed an issue with isOverShallow not working due to a DnD API change

### DIFF
--- a/src/React/Basic/ReactDND.js
+++ b/src/React/Basic/ReactDND.js
@@ -104,7 +104,7 @@ exports.unsafeCreateDropTarget = function(toMaybe, type) {
     return {
       canDrop: flags.canDrop ? monitor.canDrop() : toMaybe(null),
       isOver: monitor.isOver(),
-      isOverShallow: monitor.isOver(true),
+      isOverShallow: monitor.isOver({ shallow: true }),
       dropResult: toMaybe(monitor.getDropResult()),
       didDrop: monitor.didDrop()
     };


### PR DESCRIPTION
This is now working with the version of `react-dnd` required by `react-dnd-basic`.